### PR TITLE
Added Turkish locale

### DIFF
--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1,0 +1,13 @@
+{
+  "locale-name": "Türkçe",
+  "locale-author": "ozgurg",
+  "header-title": "PUBG SUNUCU PINGLERİ",
+  "public-message": "Hoş geldiniz! Websitesini yeniledik, eksik özellikleri lütfen <a href='http://github.com/disquse/pubgserversping'>GitHub</a> issues bölümünden bize bildirin!",
+  "ping-button": "Ping",
+  "about-button": "Hakkında",
+  "clear-button": "Tümünü temizle",
+  "locale-button": "Dil",
+  "close-button": "Kapat",
+  "no-selected-servers": "En az 1 sunucu seçmeniz gerekiyor!",
+  "something-is-broken": "Oops, birisi bir şeyi bozmuş gibi görünüyor :( Daha sonra tekrar deneyin!"
+}


### PR DESCRIPTION
I added Turkish locale.
Actually "ping" equals to "gecikme" but "ping" is used more in Turkish. So that's why I didn't translate this word.


Also these words cannot be translatable in code:

![](https://user-images.githubusercontent.com/6717356/93008445-5ee4ee00-f57d-11ea-9f03-81d09cf78534.png)

